### PR TITLE
Validate duplicated TimetabledPassingTime ids

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito-core.version}</version>

--- a/src/main/java/org/entur/netex/validation/validator/xpath/DefaultValidationTreeFactory.java
+++ b/src/main/java/org/entur/netex/validation/validator/xpath/DefaultValidationTreeFactory.java
@@ -3,19 +3,7 @@ package org.entur.netex.validation.validator.xpath;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
-import org.entur.netex.validation.validator.xpath.rules.ValidateAllowedBookingAccessProperty;
-import org.entur.netex.validation.validator.xpath.rules.ValidateAllowedBookingMethodProperty;
-import org.entur.netex.validation.validator.xpath.rules.ValidateAllowedBookingWhenProperty;
-import org.entur.netex.validation.validator.xpath.rules.ValidateAllowedBuyWhenProperty;
-import org.entur.netex.validation.validator.xpath.rules.ValidateAllowedFlexibleLineType;
-import org.entur.netex.validation.validator.xpath.rules.ValidateAllowedFlexibleServiceType;
-import org.entur.netex.validation.validator.xpath.rules.ValidateAtLeastOne;
-import org.entur.netex.validation.validator.xpath.rules.ValidateExactlyOne;
-import org.entur.netex.validation.validator.xpath.rules.ValidateMandatoryBookingProperty;
-import org.entur.netex.validation.validator.xpath.rules.ValidateMandatoryBookingWhenOrMinimumBookingPeriodProperty;
-import org.entur.netex.validation.validator.xpath.rules.ValidateNotExist;
-import org.entur.netex.validation.validator.xpath.rules.ValidatedAllowedTransportMode;
-import org.entur.netex.validation.validator.xpath.rules.ValidatedAllowedTransportSubMode;
+import org.entur.netex.validation.validator.xpath.rules.*;
 
 /**
  * Build the tree of XPath validation rules.
@@ -688,6 +676,10 @@ public class DefaultValidationTreeFactory implements ValidationTreeFactory {
         "Missing version on TimetabledPassingTime",
         "SERVICE_JOURNEY_9"
       )
+    );
+
+    validationTree.addValidationRule(
+      new ValidateDuplicatedTimetabledPassingTimeId("")
     );
 
     validationTree.addValidationRule(

--- a/src/main/java/org/entur/netex/validation/validator/xpath/rules/ValidateDuplicatedTimetabledPassingTimeId.java
+++ b/src/main/java/org/entur/netex/validation/validator/xpath/rules/ValidateDuplicatedTimetabledPassingTimeId.java
@@ -1,0 +1,79 @@
+package org.entur.netex.validation.validator.xpath.rules;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import net.sf.saxon.s9api.*;
+import org.entur.netex.validation.exception.NetexValidationException;
+import org.entur.netex.validation.validator.DataLocation;
+import org.entur.netex.validation.validator.xpath.AbstractXPathValidationRule;
+import org.entur.netex.validation.validator.xpath.XPathValidationContext;
+import org.entur.netex.validation.validator.xpath.XPathValidationReportEntry;
+
+/**
+ * Validate that there is no duplicated TimetabledPassingTimes NeTEx id within a Line file.
+ * For most NeTEx entities, the NeTEx XSD verifies that IDs are unique, but no such check exists for
+ * TimetabledPassingTimes.
+ */
+public class ValidateDuplicatedTimetabledPassingTimeId
+  extends AbstractXPathValidationRule {
+
+  private static final String MESSAGE =
+    "Non-unique NeTEx id for TimetabledPassingTime";
+  public static final String RULE_NAME = "SERVICE_JOURNEY_17";
+  private final String context;
+
+  public ValidateDuplicatedTimetabledPassingTimeId(String context) {
+    this.context = context;
+  }
+
+  @Override
+  public List<XPathValidationReportEntry> validate(
+    XPathValidationContext validationContext
+  ) {
+    try {
+      XPathSelector selector = validationContext
+        .getNetexXMLParser()
+        .getXPathCompiler()
+        .compile(
+          context +
+          "vehicleJourneys/ServiceJourney/passingTimes/TimetabledPassingTime[@id]"
+        )
+        .load();
+      selector.setContextItem(validationContext.getXmlNode());
+      XdmValue nodes = selector.evaluate();
+      Set<String> foundIds = new HashSet<>();
+      List<XPathValidationReportEntry> validationReportEntries =
+        new ArrayList<>();
+      for (XdmItem item : nodes) {
+        XdmNode xdmNode = (XdmNode) item;
+        String id = xdmNode.getAttributeValue(new QName("id"));
+        if (foundIds.contains(id)) {
+          DataLocation dataLocation = getXdmNodeLocation(
+            validationContext.getFileName(),
+            xdmNode
+          );
+          validationReportEntries.add(
+            new XPathValidationReportEntry(MESSAGE, RULE_NAME, dataLocation)
+          );
+        } else {
+          foundIds.add(id);
+        }
+      }
+      return validationReportEntries;
+    } catch (SaxonApiException e) {
+      throw new NetexValidationException("Error while validating rule", e);
+    }
+  }
+
+  @Override
+  public String getMessage() {
+    return MESSAGE;
+  }
+
+  @Override
+  public String getCode() {
+    return RULE_NAME;
+  }
+}

--- a/src/main/resources/configuration.default.yaml
+++ b/src/main/resources/configuration.default.yaml
@@ -372,6 +372,9 @@ validationRuleConfigs:
   - code: SERVICE_JOURNEY_9
     name: ServiceJourney missing version on TimetabledPassingTime
     severity: WARNING
+  - code: SERVICE_JOURNEY_17
+    name: ServiceJourney duplicated TimetabledPassingTime id
+    severity: ERROR
   - code: SERVICE_LINK_1
     name: ServiceLink missing FromPointRef
     severity: ERROR

--- a/src/test/java/org/entur/netex/validation/validator/xpath/rules/ValidateDuplicatedTimetabledPassingTimeIdTest.java
+++ b/src/test/java/org/entur/netex/validation/validator/xpath/rules/ValidateDuplicatedTimetabledPassingTimeIdTest.java
@@ -1,0 +1,134 @@
+package org.entur.netex.validation.validator.xpath.rules;
+
+import java.util.List;
+import java.util.Set;
+import net.sf.saxon.s9api.XdmNode;
+import org.entur.netex.validation.validator.xpath.XPathValidationContext;
+import org.entur.netex.validation.validator.xpath.XPathValidationReportEntry;
+import org.entur.netex.validation.xml.NetexXMLParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ValidateDuplicatedTimetabledPassingTimeIdTest {
+
+  public static final String TEST_CODESPACE = "FLI";
+  private static final NetexXMLParser NETEX_XML_PARSER = new NetexXMLParser(
+    Set.of()
+  );
+  private static final String NETEX_FRAGMENT =
+    """
+                    <vehicleJourneys xmlns="http://www.netex.org.uk/netex">
+                           <ServiceJourney version="1708599352" id="FLI:ServiceJourney:93b4d4ba65">
+                               <Name>Oslo (Busterminalen Galleriet)</Name>
+                               <dayTypes>
+                                    <DayTypeRef ref="FLI:DayType:0319e54a8e"/>
+                               </dayTypes>
+                               <JourneyPatternRef ref="FLI:JourneyPattern:dc8d8815ee" version="1708599352"/>
+                               <OperatorRef ref="FLI:Operator:FlixBus"/>
+                               <LineRef ref="FLI:Line:1d81e78284" version="1"/>
+                               <passingTimes>
+                                   <TimetabledPassingTime version="1708599352" ${ID_1}>
+                                       <StopPointInJourneyPatternRef ref="FLI:StopPointInJourneyPattern:276cef3c14-1" version="1708599352"/>
+                                       <DepartureTime>18:00:00</DepartureTime>
+                                   </TimetabledPassingTime>
+                                   <TimetabledPassingTime version="1708599352" ${ID_2}>
+                                       <StopPointInJourneyPatternRef ref="FLI:StopPointInJourneyPattern:593de1325d-2" version="1708599352"/>
+                                       <ArrivalTime>19:00:00</ArrivalTime>
+                                       <DepartureTime>19:05:00</DepartureTime>
+                                   </TimetabledPassingTime>
+                               </passingTimes>
+                           </ServiceJourney>
+                           <ServiceJourney version="1708599352" id="FLI:ServiceJourney:ee0431e315">
+                               <Name>Oslo (Busterminalen Galleriet)</Name>
+                               <dayTypes>
+                                    <DayTypeRef ref="FLI:DayType:557828265f"/>
+                               </dayTypes>
+                               <JourneyPatternRef ref="FLI:JourneyPattern:dc8d8815ee" version="1708599352"/>
+                               <OperatorRef ref="FLI:Operator:FlixBus"/>
+                               <LineRef ref="FLI:Line:1d81e78284" version="1"/>
+                               <passingTimes>
+                                   <TimetabledPassingTime version="1708599352" ${ID_3}>
+                                       <StopPointInJourneyPatternRef ref="FLI:StopPointInJourneyPattern:276cef3c14-1" version="1708599352"/>
+                                       <DepartureTime>18:00:00</DepartureTime>
+                                   </TimetabledPassingTime>
+                                   <TimetabledPassingTime version="1708599352" ${ID_4}>
+                                       <StopPointInJourneyPatternRef ref="FLI:StopPointInJourneyPattern:593de1325d-2" version="1708599352"/>
+                                       <ArrivalTime>19:00:00</ArrivalTime>
+                                       <DepartureTime>19:05:00</DepartureTime>
+                                   </TimetabledPassingTime>
+                               </passingTimes>
+                           </ServiceJourney>
+                    </vehicleJourneys>
+                    """;
+
+  static List<Arguments> timetabledPassingTimesIdCases() {
+    return List.of(
+      Arguments.of(
+        List.of(
+          "id=\"FLI:TimetabledPassingTime:ID1\"",
+          "id=\"FLI:TimetabledPassingTime:ID2\"",
+          "id=\"FLI:TimetabledPassingTime:ID3\"",
+          "id=\"FLI:TimetabledPassingTime:ID4\""
+        ),
+        true,
+        "Non-duplicated IDs should be accepted"
+      ),
+      Arguments.of(
+        List.of("", "", "", ""),
+        true,
+        "Missing IDs should be accepted"
+      ),
+      Arguments.of(
+        List.of(
+          "id=\"FLI:TimetabledPassingTime:ID1\"",
+          "id=\"FLI:TimetabledPassingTime:ID2\"",
+          "id=\"FLI:TimetabledPassingTime:ID3\"",
+          "id=\"FLI:TimetabledPassingTime:ID1\""
+        ),
+        false,
+        "Duplicated IDs should be rejected"
+      )
+    );
+  }
+
+  /**
+   */
+  @ParameterizedTest
+  @MethodSource("timetabledPassingTimesIdCases")
+  void testTimetabledPassingTimesIds(
+    List<String> ids,
+    boolean accepted,
+    String expectedMessage
+  ) {
+    ValidateDuplicatedTimetabledPassingTimeId validateDuplicatedTimetabledPassingTimeId =
+      new ValidateDuplicatedTimetabledPassingTimeId("/");
+
+    String vehicleJourneysFragment = NETEX_FRAGMENT
+      .replace("${ID_1}", ids.get(0))
+      .replace("${ID_2}", ids.get(1))
+      .replace("${ID_3}", ids.get(2))
+      .replace("${ID_4}", ids.get(3));
+
+    XdmNode document = NETEX_XML_PARSER.parseStringToXdmNode(
+      vehicleJourneysFragment
+    );
+    XPathValidationContext xpathValidationContext = new XPathValidationContext(
+      document,
+      NETEX_XML_PARSER,
+      TEST_CODESPACE,
+      null
+    );
+    List<XPathValidationReportEntry> xPathValidationReportEntries =
+      validateDuplicatedTimetabledPassingTimeId.validate(
+        xpathValidationContext
+      );
+    Assertions.assertNotNull(xPathValidationReportEntries);
+    Assertions.assertEquals(
+      accepted,
+      xPathValidationReportEntries.isEmpty(),
+      expectedMessage
+    );
+  }
+}


### PR DESCRIPTION
Add a validation rule for duplicated TimetabledPassingTime NeTEx ID within a line file.
This validation is missing in the NeTEx XML schema.
Uniqueness validation across several Line files is already handled by another validator.