### PR TITLE
Fix missing submode on stop place

### DIFF
--- a/src/main/java/org/entur/netex/validation/validator/model/TransportModeAndSubMode.java
+++ b/src/main/java/org/entur/netex/validation/validator/model/TransportModeAndSubMode.java
@@ -15,15 +15,16 @@ public record TransportModeAndSubMode(
   AllVehicleModesOfTransportEnumeration mode,
   TransportSubMode subMode
 ) {
-  private static final Logger LOGGER = LoggerFactory.getLogger(
-    TransportModeAndSubMode.class
-  );
-
   public TransportModeAndSubMode {
     Objects.requireNonNull(mode, "Transport mode cannot be null");
     Objects.requireNonNull(mode, "Transport submode cannot be null");
   }
 
+  /**
+   * Return the transport mode and sub-mode for the given stop place.
+   * Return null if the transport mode is null.
+   * The submode can be missing, in which case it is mapped to TransportSubMode.MISSING.
+   */
   @Nullable
   public static TransportModeAndSubMode of(StopPlace stopPlace) {
     AllVehicleModesOfTransportEnumeration transportMode =
@@ -34,9 +35,16 @@ public record TransportModeAndSubMode(
     return TransportSubMode
       .of(stopPlace)
       .map(submode -> new TransportModeAndSubMode(transportMode, submode))
-      .orElse(null);
+      .orElse(
+        new TransportModeAndSubMode(transportMode, TransportSubMode.MISSING)
+      );
   }
 
+  /**
+   * Return the transport mode and sub-mode for the corresponding NeTEx structures.
+   * Return null if the transport mode is null
+   * The submode can be missing, in which case it is mapped to TransportSubMode.MISSING.
+   */
   @Nullable
   public static TransportModeAndSubMode of(
     AllVehicleModesOfTransportEnumeration transportMode,

--- a/src/test/java/org/entur/netex/validation/validator/model/TransportModeAndSubModeTest.java
+++ b/src/test/java/org/entur/netex/validation/validator/model/TransportModeAndSubModeTest.java
@@ -20,6 +20,16 @@ class TransportModeAndSubModeTest {
   }
 
   @Test
+  void testMissingTransportSubModeFromStopPlace() {
+    StopPlace stopPlace = new StopPlace();
+    stopPlace.withTransportMode(AllVehicleModesOfTransportEnumeration.RAIL);
+    TransportModeAndSubMode transportModeAndSubMode =
+      TransportModeAndSubMode.of(stopPlace);
+    assertNotNull(transportModeAndSubMode);
+    assertEquals(TransportSubMode.MISSING, transportModeAndSubMode.subMode());
+  }
+
+  @Test
   void testCreateTransportModeAndSubModeFromStopPlace() {
     StopPlace stopPlace = new StopPlace();
     stopPlace


### PR DESCRIPTION
### Summary

Fix the resolution of the transport mode and submode of a stop place when only the transport mode is specified.

### Issue

No

### Unit tests

Added unit test

### Documentation

No
