### PR TITLE
Add validation rules for ServiceLinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ The NeTEx validator library comes with the following rule set by default:
 | SERVICE_LINK_1                           |                             ServiceLink missing FromPointRef                             |
 | SERVICE_LINK_2                           |                              ServiceLink missing ToPointRef                              |
 | SERVICE_LINK_3                           |                         ServiceLink missing element Projections                          |
+| SERVICE_LINK_4                           |                           ServiceLink missing coordinate list                            |
+| SERVICE_LINK_5                           |                              ServiceLink less than 2 points                              |
 | SITE_FRAME_IN_COMMON_FILE                |                      SiteFrame unexpected SiteFrame in Common file                       |
 | SITE_FRAME_IN_LINE_FILE                  |                       SiteFrame unexpected SiteFrame in Line file                        |
 | TIMETABLE_FRAME_IN_COMMON_FILE           |                          TimetableFrame illegal in Common file                           |

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.entur</groupId>
     <artifactId>netex-validator-java</artifactId>
-    <version>9.0.5-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
 
     <name>netex-validator-java</name>
     <description>Library for validating NeTEx datasets against the Nordic NeTEx Profile.</description>

--- a/src/main/java/org/entur/netex/validation/validator/xpath/tree/DefaultServiceFrameValidationTreeFactory.java
+++ b/src/main/java/org/entur/netex/validation/validator/xpath/tree/DefaultServiceFrameValidationTreeFactory.java
@@ -59,6 +59,8 @@ public class DefaultServiceFrameValidationTreeFactory
   public static final String CODE_SERVICE_LINK_1 = "SERVICE_LINK_1";
   public static final String CODE_SERVICE_LINK_2 = "SERVICE_LINK_2";
   public static final String CODE_SERVICE_LINK_3 = "SERVICE_LINK_3";
+  public static final String CODE_SERVICE_LINK_4 = "SERVICE_LINK_4";
+  public static final String CODE_SERVICE_LINK_5 = "SERVICE_LINK_5";
   public static final String CODE_FLEXIBLE_LINE_1 = "FLEXIBLE_LINE_1";
   public static final String CODE_FLEXIBLE_LINE_10 = "FLEXIBLE_LINE_10";
   public static final String CODE_FLEXIBLE_LINE_11 = "FLEXIBLE_LINE_11";
@@ -176,11 +178,29 @@ public class DefaultServiceFrameValidationTreeFactory
       )
       .withRule(
         new ValidateNotExist(
-          "serviceLinks/ServiceLink/projections/LinkSequenceProjection/g:LineString/g:posList[not(normalize-space(text()))]",
+          "serviceLinks/ServiceLink[not(projections)]",
           CODE_SERVICE_LINK_3,
           "ServiceLink missing element Projections",
           "Missing projections element on ServiceLink",
+          Severity.WARNING
+        )
+      )
+      .withRule(
+        new ValidateNotExist(
+          "serviceLinks/ServiceLink/projections/LinkSequenceProjection/g:LineString/g:posList[not(normalize-space(text()))]",
+          CODE_SERVICE_LINK_4,
+          "ServiceLink missing coordinate list",
+          "Missing coordinates list on ServiceLink",
           Severity.ERROR
+        )
+      )
+      .withRule(
+        new ValidateNotExist(
+          "serviceLinks/ServiceLink/projections/LinkSequenceProjection/g:LineString[count(g:pos) < 2]",
+          CODE_SERVICE_LINK_5,
+          "ServiceLink less than 2 points",
+          "Less then 2 points on ServiceLink",
+          Severity.WARNING
         )
       )
       .withRule(

--- a/src/test/java/org/entur/netex/validation/validator/xpath/tree/DefaultServiceFrameValidationTreeFactoryTest.java
+++ b/src/test/java/org/entur/netex/validation/validator/xpath/tree/DefaultServiceFrameValidationTreeFactoryTest.java
@@ -11,6 +11,7 @@ import org.entur.netex.validation.validator.ValidationIssue;
 import org.entur.netex.validation.validator.xpath.ValidationTree;
 import org.entur.netex.validation.validator.xpath.XPathRuleValidationContext;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -140,6 +141,100 @@ class DefaultServiceFrameValidationTreeFactoryTest {
       
       """;
 
+  private static final String NETEX_FRAGMENT_INVALID_SERVICE_LINK_NO_PROJECTION =
+    """
+<ServiceFrame xmlns="http://www.netex.org.uk/netex">
+     <serviceLinks>
+        <ServiceLink id="BRA:ServiceLink:210108111955158_2_210108111955389_1_2030" version="1563">
+              <Distance>2030.0</Distance>
+              <FromPointRef ref="BRA:ScheduledStopPoint:6233600_2" version="1563" />
+              <ToPointRef ref="BRA:ScheduledStopPoint:6239930_1" version="1563" />
+        </ServiceLink>
+    </serviceLinks>
+</ServiceFrame>
+       """;
+
+  private static final String NETEX_FRAGMENT_INVALID_SERVICE_LINK_NO_COORDINATE_LIST =
+    """
+<ServiceFrame xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2">
+     <serviceLinks>
+        <ServiceLink id="BRA:ServiceLink:210108111955158_2_210108111955389_1_2030" version="1563">
+              <Distance>2030.0</Distance>
+                           <projections>
+                              <LinkSequenceProjection id="BRA:LinkSequenceProjection:210108111955158_2_210108111955389_1_2030" version="1563">
+                                <gml:LineString gml:id="id_210108111955158_2_210108111955389_1_2030" srsName="WGS84">
+                                <gml:posList count="2" srsDimension="2"></gml:posList>
+                                </gml:LineString>
+                              </LinkSequenceProjection>
+                           </projections>
+              <FromPointRef ref="BRA:ScheduledStopPoint:6233600_2" version="1563" />
+              <ToPointRef ref="BRA:ScheduledStopPoint:6239930_1" version="1563" />
+        </ServiceLink>
+    </serviceLinks>
+</ServiceFrame>
+       """;
+
+  private static final String NETEX_FRAGMENT_SERVICE_LINK_VALID_COORDINATE_LIST =
+    """
+<ServiceFrame xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2">
+     <serviceLinks>
+        <ServiceLink id="BRA:ServiceLink:210108111955158_2_210108111955389_1_2030" version="1563">
+              <Distance>2030.0</Distance>
+                           <projections>
+                              <LinkSequenceProjection id="BRA:LinkSequenceProjection:210108111955158_2_210108111955389_1_2030" version="1563">
+                                <gml:LineString gml:id="id_210108111955158_2_210108111955389_1_2030" srsName="WGS84">
+                                  <gml:posList count="2" srsDimension="2">59.551598 9.803644  59.5307 9.805698</gml:posList>
+                                </gml:LineString>
+                              </LinkSequenceProjection>
+                           </projections>
+              <FromPointRef ref="BRA:ScheduledStopPoint:6233600_2" version="1563" />
+              <ToPointRef ref="BRA:ScheduledStopPoint:6239930_1" version="1563" />
+        </ServiceLink>
+    </serviceLinks>
+</ServiceFrame>
+       """;
+
+  private static final String NETEX_FRAGMENT_INVALID_SERVICE_LINK_LESS_THAN_TWO_POINTS =
+    """
+<ServiceFrame xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2">
+     <serviceLinks>
+        <ServiceLink id="BRA:ServiceLink:210108111955158_2_210108111955389_1_2030" version="1563">
+              <Distance>2030.0</Distance>
+                           <projections>
+                              <LinkSequenceProjection id="BRA:LinkSequenceProjection:210108111955158_2_210108111955389_1_2030" version="1563">
+                                <gml:LineString gml:id="id_210108111955158_2_210108111955389_1_2030" srsName="WGS84">
+                                   <gml:pos>60.075463 9.121449</gml:pos>
+                                </gml:LineString>
+                              </LinkSequenceProjection>
+                           </projections>
+              <FromPointRef ref="BRA:ScheduledStopPoint:6233600_2" version="1563" />
+              <ToPointRef ref="BRA:ScheduledStopPoint:6239930_1" version="1563" />
+        </ServiceLink>
+    </serviceLinks>
+</ServiceFrame>
+       """;
+
+  private static final String NETEX_FRAGMENT_SERVICE_LINK_VALID_TWO_POINTS =
+    """
+<ServiceFrame xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2">
+     <serviceLinks>
+        <ServiceLink id="BRA:ServiceLink:210108111955158_2_210108111955389_1_2030" version="1563">
+              <Distance>2030.0</Distance>
+                           <projections>
+                              <LinkSequenceProjection id="BRA:LinkSequenceProjection:210108111955158_2_210108111955389_1_2030" version="1563">
+                                <gml:LineString gml:id="id_210108111955158_2_210108111955389_1_2030" srsName="WGS84">
+                                   <gml:pos>60.075463 9.121449</gml:pos>
+                                    <gml:pos>60.07577 9.121238</gml:pos>
+                                </gml:LineString>
+                              </LinkSequenceProjection>
+                           </projections>
+              <FromPointRef ref="BRA:ScheduledStopPoint:6233600_2" version="1563" />
+              <ToPointRef ref="BRA:ScheduledStopPoint:6239930_1" version="1563" />
+        </ServiceLink>
+    </serviceLinks>
+</ServiceFrame>
+       """;
+
   private ValidationTree validationTree;
 
   @BeforeEach
@@ -199,6 +294,73 @@ class DefaultServiceFrameValidationTreeFactoryTest {
     List<ValidationIssue> validationIssues = validationTree.validate(
       xpathValidationContext,
       code
+    );
+    assertTrue(validationIssues.isEmpty());
+  }
+
+  @Test
+  void testMissingProjectionOnServiceLink() {
+    XPathRuleValidationContext xpathValidationContext =
+      TestValidationContextBuilder
+        .ofNetexFragment(NETEX_FRAGMENT_INVALID_SERVICE_LINK_NO_PROJECTION)
+        .build();
+    List<ValidationIssue> validationIssues = validationTree.validate(
+      xpathValidationContext,
+      CODE_SERVICE_LINK_3
+    );
+    assertEquals(1, validationIssues.size());
+  }
+
+  @Test
+  void testMissingCoordinateListOnServiceLink() {
+    XPathRuleValidationContext xpathValidationContext =
+      TestValidationContextBuilder
+        .ofNetexFragment(NETEX_FRAGMENT_INVALID_SERVICE_LINK_NO_COORDINATE_LIST)
+        .build();
+    List<ValidationIssue> validationIssues = validationTree.validate(
+      xpathValidationContext,
+      CODE_SERVICE_LINK_4
+    );
+    assertEquals(1, validationIssues.size());
+  }
+
+  @Test
+  void testValidCoordinateListOnServiceLink() {
+    XPathRuleValidationContext xpathValidationContext =
+      TestValidationContextBuilder
+        .ofNetexFragment(NETEX_FRAGMENT_SERVICE_LINK_VALID_COORDINATE_LIST)
+        .build();
+    List<ValidationIssue> validationIssues = validationTree.validate(
+      xpathValidationContext,
+      CODE_SERVICE_LINK_4
+    );
+    assertTrue(validationIssues.isEmpty());
+  }
+
+  @Test
+  void testLessThanTwoPointsOnServiceLink() {
+    XPathRuleValidationContext xpathValidationContext =
+      TestValidationContextBuilder
+        .ofNetexFragment(
+          NETEX_FRAGMENT_INVALID_SERVICE_LINK_LESS_THAN_TWO_POINTS
+        )
+        .build();
+    List<ValidationIssue> validationIssues = validationTree.validate(
+      xpathValidationContext,
+      CODE_SERVICE_LINK_5
+    );
+    assertEquals(1, validationIssues.size());
+  }
+
+  @Test
+  void testServiceLinkWithTwoPoints() {
+    XPathRuleValidationContext xpathValidationContext =
+      TestValidationContextBuilder
+        .ofNetexFragment(NETEX_FRAGMENT_SERVICE_LINK_VALID_TWO_POINTS)
+        .build();
+    List<ValidationIssue> validationIssues = validationTree.validate(
+      xpathValidationContext,
+      CODE_SERVICE_LINK_5
     );
     assertTrue(validationIssues.isEmpty());
   }


### PR DESCRIPTION
### Summary

Add 3 validation rules for ServiceLink:
- check if projections are missing
- check if the list of coordinates is empty (only for <gml:posList> format)
- check if the list of coordinates has less than 2 points (only for <gml:pos> format)

### Issue

No

### Unit tests

Added unit test


### Documentation

Updated README

### Bumping the project version

New minor version

