### PR TITLE
Disable Maven Central rules check to include OSGEO repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,7 @@
                                         <active>SNAPSHOT</active>
                                         <url>https://ossrh-staging-api.central.sonatype.com/service/local</url>
                                         <snapshotUrl>https://central.sonatype.com/repository/maven-snapshots</snapshotUrl>
-                                        <applyMavenCentralRules>true</applyMavenCentralRules>
+                                        <applyMavenCentralRules>false</applyMavenCentralRules>
                                         <snapshotSupported>true</snapshotSupported>
                                         <closeRepository>true</closeRepository>
                                         <releaseRepository>true</releaseRepository>


### PR DESCRIPTION
Disable Maven central rules check in JReleaser to be able to include the <repositories> block in pom.xml
The OSGEO repository is required (artifacts missing in Maven Central)