### PR TITLE
Add parking AvailabilityCondition validation

### DIFF
--- a/src/main/java/org/entur/netex/validation/validator/xpath/tree/DefaultParkingValidationTreeFactory.java
+++ b/src/main/java/org/entur/netex/validation/validator/xpath/tree/DefaultParkingValidationTreeFactory.java
@@ -1,0 +1,52 @@
+package org.entur.netex.validation.validator.xpath.tree;
+
+import org.entur.netex.validation.validator.Severity;
+import org.entur.netex.validation.validator.xpath.ValidationTreeFactory;
+import org.entur.netex.validation.validator.xpath.rules.ValidateNotExist;
+
+/**
+ * Construct a validation tree builder for Parking elements within a SiteFrame.
+ * Validates the structure of AvailabilityCondition entries on Parking entities,
+ * including DayTypeRef presence and Timeband time range validity.
+ */
+public class DefaultParkingValidationTreeFactory implements ValidationTreeFactory {
+
+  public static final String CODE_PARKING_AVAILABILITY_CONDITION_WITHOUT_DAY_TYPE =
+    "PARKING_AVAILABILITY_CONDITION_WITHOUT_DAY_TYPE";
+  public static final String CODE_PARKING_TIMEBAND_WITHOUT_START_OR_END_TIME =
+    "PARKING_TIMEBAND_WITHOUT_START_OR_END_TIME";
+  public static final String CODE_PARKING_TIMEBAND_INVALID_TIME_RANGE =
+    "PARKING_TIMEBAND_INVALID_TIME_RANGE";
+
+  @Override
+  public ValidationTreeBuilder builder() {
+    return new ValidationTreeBuilder("Parking", "SiteFrame/parkings/Parking")
+      .withRule(
+        new ValidateNotExist(
+          "validityConditions/AvailabilityCondition[not(dayTypes/DayTypeRef)]",
+          CODE_PARKING_AVAILABILITY_CONDITION_WITHOUT_DAY_TYPE,
+          "Parking AvailabilityCondition missing DayTypeRef",
+          "Each AvailabilityCondition on a Parking must reference a DayType via dayTypes/DayTypeRef",
+          Severity.ERROR
+        )
+      )
+      .withRule(
+        new ValidateNotExist(
+          "validityConditions/AvailabilityCondition/timebands/Timeband[not(StartTime) or not(EndTime)]",
+          CODE_PARKING_TIMEBAND_WITHOUT_START_OR_END_TIME,
+          "Parking Timeband missing StartTime or EndTime",
+          "Each Timeband on a Parking AvailabilityCondition must have both StartTime and EndTime",
+          Severity.ERROR
+        )
+      )
+      .withRule(
+        new ValidateNotExist(
+          "validityConditions/AvailabilityCondition/timebands/Timeband[StartTime and EndTime and StartTime != '00:00:00' and EndTime != '00:00:00' and EndTime < StartTime]",
+          CODE_PARKING_TIMEBAND_INVALID_TIME_RANGE,
+          "Parking Timeband EndTime before StartTime",
+          "Timeband EndTime must not be before StartTime (use 00:00:00 to denote midnight/24h)",
+          Severity.ERROR
+        )
+      );
+  }
+}

--- a/src/main/java/org/entur/netex/validation/validator/xpath/tree/DefaultSiteFrameValidationTreeFactory.java
+++ b/src/main/java/org/entur/netex/validation/validator/xpath/tree/DefaultSiteFrameValidationTreeFactory.java
@@ -14,7 +14,7 @@ public class DefaultSiteFrameValidationTreeFactory implements ValidationTreeFact
     return new ValidationTreeBuilder("Site Frame", "SiteFrame")
       .withRuleForLineFile(
         new ValidateNotExist(
-          ".",
+          ".[not(parkings/Parking)]",
           CODE_SITE_FRAME_IN_LINE_FILE,
           "SiteFrame unexpected SiteFrame in Line file",
           "Unexpected element SiteFrame. It will be ignored",
@@ -23,7 +23,7 @@ public class DefaultSiteFrameValidationTreeFactory implements ValidationTreeFact
       )
       .withRuleForCommonFile(
         new ValidateNotExist(
-          ".",
+          ".[not(parkings/Parking)]",
           CODE_SITE_FRAME_IN_COMMON_FILE,
           "SiteFrame unexpected SiteFrame in Common file",
           "Unexpected element SiteFrame. It will be ignored",

--- a/src/main/java/org/entur/netex/validation/validator/xpath/tree/PublicationDeliveryValidationTreeFactory.java
+++ b/src/main/java/org/entur/netex/validation/validator/xpath/tree/PublicationDeliveryValidationTreeFactory.java
@@ -33,6 +33,8 @@ public class PublicationDeliveryValidationTreeFactory implements ValidationTreeF
     new DefaultVehicleScheduleFrameValidationTreeFactory().builder();
   private ValidationTreeBuilder multipleFramesValidationTreeBuilder =
     new DefaultMultipleFramesValidationTreeFactory().builder();
+  private ValidationTreeBuilder parkingValidationTreeBuilder =
+    new DefaultParkingValidationTreeFactory().builder();
 
   @Override
   public ValidationTreeBuilder builder() {
@@ -78,6 +80,9 @@ public class PublicationDeliveryValidationTreeFactory implements ValidationTreeF
         dataObjectsValidationTree.withSubTreeBuilder(tree);
         framesInCompositeFrameValidationTree.withSubTreeBuilder(tree);
       });
+
+    dataObjectsValidationTree.withSubTreeBuilder(parkingValidationTreeBuilder);
+    framesInCompositeFrameValidationTree.withSubTreeBuilder(parkingValidationTreeBuilder);
 
     return validationTreeBuilder;
   }
@@ -182,5 +187,15 @@ public class PublicationDeliveryValidationTreeFactory implements ValidationTreeF
     ValidationTreeBuilder multipleFramesValidationTreeBuilder
   ) {
     this.multipleFramesValidationTreeBuilder = multipleFramesValidationTreeBuilder;
+  }
+
+  public ValidationTreeBuilder parkingValidationTreeBuilder() {
+    return parkingValidationTreeBuilder;
+  }
+
+  public void setParkingValidationTreeBuilder(
+    ValidationTreeBuilder parkingValidationTreeBuilder
+  ) {
+    this.parkingValidationTreeBuilder = parkingValidationTreeBuilder;
   }
 }

--- a/src/test/java/org/entur/netex/validation/validator/xpath/tree/DefaultParkingValidationTreeFactoryIntegrationTest.java
+++ b/src/test/java/org/entur/netex/validation/validator/xpath/tree/DefaultParkingValidationTreeFactoryIntegrationTest.java
@@ -1,0 +1,217 @@
+package org.entur.netex.validation.validator.xpath.tree;
+
+import static org.entur.netex.validation.validator.xpath.tree.DefaultParkingValidationTreeFactory.CODE_PARKING_AVAILABILITY_CONDITION_WITHOUT_DAY_TYPE;
+import static org.entur.netex.validation.validator.xpath.tree.DefaultParkingValidationTreeFactory.CODE_PARKING_TIMEBAND_INVALID_TIME_RANGE;
+import static org.entur.netex.validation.validator.xpath.tree.DefaultParkingValidationTreeFactory.CODE_PARKING_TIMEBAND_WITHOUT_START_OR_END_TIME;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import org.entur.netex.validation.validator.NetexValidatorsRunner;
+import org.entur.netex.validation.validator.ValidationReport;
+import org.entur.netex.validation.validator.ValidationReportEntry;
+import org.entur.netex.validation.validator.schema.NetexSchemaValidator;
+import org.entur.netex.validation.validator.xpath.XPathRuleValidator;
+import org.entur.netex.validation.xml.NetexXMLParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for parking AvailabilityCondition validation rules.
+ * Runs the full NetexValidatorsRunner pipeline (schema + XPath) against
+ * minimal parking NeTEx files to verify that rules fire on invalid data
+ * and are silent on valid data.
+ */
+class DefaultParkingValidationTreeFactoryIntegrationTest {
+
+  private static final String CODESPACE = "FSR";
+  private static final String REPORT_ID = "test-report";
+  private static final String FILE_NAME = "FSR_parking.xml";
+
+  /**
+   * Minimal parking NeTEx that passes schema validation and satisfies all three
+   * parking rules. Used as the base for "bad" variants by replacing specific elements.
+   */
+  private static final String VALID_PARKING_NETEX =
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <PublicationDelivery
+        xmlns="http://www.netex.org.uk/netex"
+        version="1.13:NO-NeTEx-networktimetable:1.3">
+      <PublicationTimestamp>2026-01-01T00:00:00</PublicationTimestamp>
+      <ParticipantRef>FSR</ParticipantRef>
+      <dataObjects>
+        <ResourceFrame version="1" id="FSR:ResourceFrame:1">
+          <validityConditions>
+            <AvailabilityCondition version="1" id="FSR:AvailabilityCondition:1">
+              <FromDate>2026-01-01T00:00:00</FromDate>
+              <ToDate>2030-01-01T00:00:00</ToDate>
+            </AvailabilityCondition>
+          </validityConditions>
+          <organisations>
+            <Operator version="1" id="FSR:Operator:1">
+              <Name>Test Operator</Name>
+              <OrganisationType>operator</OrganisationType>
+            </Operator>
+          </organisations>
+        </ResourceFrame>
+        <ServiceCalendarFrame version="1" id="FSR:ServiceCalendarFrame:1">
+          <dayTypes>
+            <DayType version="1" id="FSR:DayType:Weekday">
+              <Name>Weekday</Name>
+              <properties>
+                <PropertyOfDay>
+                  <DaysOfWeek>Monday Tuesday Wednesday Thursday Friday</DaysOfWeek>
+                </PropertyOfDay>
+              </properties>
+            </DayType>
+          </dayTypes>
+        </ServiceCalendarFrame>
+        <SiteFrame version="1" id="FSR:SiteFrame:1">
+          <stopPlaces>
+            <StopPlace version="1" id="FSR:StopPlace:1">
+              <Name>Test Stop</Name>
+              <StopPlaceType>other</StopPlaceType>
+            </StopPlace>
+          </stopPlaces>
+          <parkings>
+            <Parking version="1" id="FSR:Parking:1">
+              <validityConditions>
+                <AvailabilityCondition version="1" id="FSR:Parking:1:AC:1">
+                  <FromDate>2026-01-01T00:00:00</FromDate>
+                  <ToDate>2030-01-01T00:00:00</ToDate>
+                  <IsAvailable>true</IsAvailable>
+                  <dayTypes>
+                    <DayTypeRef version="1" ref="FSR:DayType:Weekday"/>
+                  </dayTypes>
+                  <timebands>
+                    <Timeband version="1" id="FSR:Parking:1:TB:1">
+                      <StartTime>08:00:00</StartTime>
+                      <EndTime>18:00:00</EndTime>
+                    </Timeband>
+                  </timebands>
+                </AvailabilityCondition>
+              </validityConditions>
+              <Name>Test Parking</Name>
+              <OperatorRef ref="FSR:Operator:1" version="1"/>
+              <ParentSiteRef ref="FSR:StopPlace:1" version="1"/>
+              <ParkingType>parkAndRide</ParkingType>
+              <ParkingLayout>openSpace</ParkingLayout>
+              <TotalCapacity>50</TotalCapacity>
+            </Parking>
+          </parkings>
+        </SiteFrame>
+      </dataObjects>
+    </PublicationDelivery>
+    """;
+
+  private NetexValidatorsRunner runner;
+
+  @BeforeEach
+  void setUp() {
+    // Use a custom entry factory that stores rule.code() in the name field so tests
+    // can assert against the CODE_* constants rather than fragile rule name strings.
+    NetexXMLParser netexXMLParser = new NetexXMLParser(Collections.emptySet());
+    NetexSchemaValidator netexSchemaValidator = new NetexSchemaValidator(100);
+    XPathRuleValidator xPathRuleValidator = new XPathRuleValidator(
+      new PublicationDeliveryValidationTreeFactory()
+    );
+    runner =
+      NetexValidatorsRunner
+        .of()
+        .withNetexXMLParser(netexXMLParser)
+        .withNetexSchemaValidator(netexSchemaValidator)
+        .withXPathValidators(List.of(xPathRuleValidator))
+        .withValidationReportEntryFactory(issue ->
+          new ValidationReportEntry(
+            issue.message(),
+            issue.rule().code(),
+            issue.rule().severity(),
+            issue.dataLocation()
+          )
+        )
+        .build();
+  }
+
+  @Test
+  void testValidParkingProducesNoParkingRuleViolations() {
+    ValidationReport report = validate(VALID_PARKING_NETEX);
+    List<String> parkingCodes = parkingRuleCodes(report);
+    assertTrue(
+      parkingCodes.isEmpty(),
+      "Expected no parking rule violations but got: " + parkingCodes
+    );
+  }
+
+  @Test
+  void testAvailabilityConditionWithoutDayTypeRefIsReported() {
+    // Remove the entire <dayTypes> block — AvailabilityCondition without dayTypes/DayTypeRef
+    String xml = VALID_PARKING_NETEX.replaceAll(
+      "\\s*<dayTypes>[^<]*<DayTypeRef[^/]*/>[^<]*</dayTypes>",
+      ""
+    );
+    ValidationReport report = validate(xml);
+    assertTrue(
+      hasCode(report, CODE_PARKING_AVAILABILITY_CONDITION_WITHOUT_DAY_TYPE),
+      "Expected " +
+      CODE_PARKING_AVAILABILITY_CONDITION_WITHOUT_DAY_TYPE +
+      " but got: " +
+      parkingRuleCodes(report)
+    );
+  }
+
+  @Test
+  void testTimebandWithoutEndTimeIsReported() {
+    String xml = VALID_PARKING_NETEX.replace("<EndTime>18:00:00</EndTime>", "");
+    ValidationReport report = validate(xml);
+    assertTrue(
+      hasCode(report, CODE_PARKING_TIMEBAND_WITHOUT_START_OR_END_TIME),
+      "Expected " +
+      CODE_PARKING_TIMEBAND_WITHOUT_START_OR_END_TIME +
+      " but got: " +
+      parkingRuleCodes(report)
+    );
+  }
+
+  @Test
+  void testTimebandWithEndTimeBeforeStartTimeIsReported() {
+    String xml = VALID_PARKING_NETEX
+      .replace("<StartTime>08:00:00</StartTime>", "<StartTime>18:00:00</StartTime>")
+      .replace("<EndTime>18:00:00</EndTime>", "<EndTime>08:00:00</EndTime>");
+    ValidationReport report = validate(xml);
+    assertTrue(
+      hasCode(report, CODE_PARKING_TIMEBAND_INVALID_TIME_RANGE),
+      "Expected " +
+      CODE_PARKING_TIMEBAND_INVALID_TIME_RANGE +
+      " but got: " +
+      parkingRuleCodes(report)
+    );
+  }
+
+  private ValidationReport validate(String xml) {
+    return runner.validate(
+      CODESPACE,
+      REPORT_ID,
+      FILE_NAME,
+      xml.getBytes(StandardCharsets.UTF_8)
+    );
+  }
+
+  private static List<String> parkingRuleCodes(ValidationReport report) {
+    return report
+      .getValidationReportEntries()
+      .stream()
+      .map(ValidationReportEntry::getName)
+      .filter(name -> name.startsWith("PARKING_"))
+      .toList();
+  }
+
+  private static boolean hasCode(ValidationReport report, String code) {
+    return report
+      .getValidationReportEntries()
+      .stream()
+      .anyMatch(e -> e.getName().equals(code));
+  }
+}

--- a/src/test/java/org/entur/netex/validation/validator/xpath/tree/DefaultParkingValidationTreeFactoryTest.java
+++ b/src/test/java/org/entur/netex/validation/validator/xpath/tree/DefaultParkingValidationTreeFactoryTest.java
@@ -1,0 +1,190 @@
+package org.entur.netex.validation.validator.xpath.tree;
+
+import static org.entur.netex.validation.validator.xpath.tree.DefaultParkingValidationTreeFactory.CODE_PARKING_AVAILABILITY_CONDITION_WITHOUT_DAY_TYPE;
+import static org.entur.netex.validation.validator.xpath.tree.DefaultParkingValidationTreeFactory.CODE_PARKING_TIMEBAND_INVALID_TIME_RANGE;
+import static org.entur.netex.validation.validator.xpath.tree.DefaultParkingValidationTreeFactory.CODE_PARKING_TIMEBAND_WITHOUT_START_OR_END_TIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.entur.netex.validation.test.xpath.support.TestValidationContextBuilder;
+import org.entur.netex.validation.validator.ValidationIssue;
+import org.entur.netex.validation.validator.xpath.ValidationTree;
+import org.entur.netex.validation.validator.xpath.XPathRuleValidationContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DefaultParkingValidationTreeFactoryTest {
+
+  private static final String NETEX_FRAGMENT_VALID =
+    """
+        <Parking xmlns="http://www.netex.org.uk/netex" version="1" id="FSR:Parking:liipi-1">
+          <validityConditions>
+            <AvailabilityCondition version="1" id="FSR:Parking:liipi-1:AvailabilityCondition:1">
+              <IsAvailable>true</IsAvailable>
+              <dayTypes>
+                <DayTypeRef ref="FSR:DayType:BusinessDay"/>
+              </dayTypes>
+              <timebands>
+                <Timeband version="1" id="FSR:Parking:liipi-1:Timeband:1">
+                  <StartTime>08:00:00</StartTime>
+                  <EndTime>20:00:00</EndTime>
+                </Timeband>
+              </timebands>
+            </AvailabilityCondition>
+            <AvailabilityCondition version="1" id="FSR:Parking:liipi-1:AvailabilityCondition:2">
+              <IsAvailable>false</IsAvailable>
+              <dayTypes>
+                <DayTypeRef ref="FSR:DayType:Sunday"/>
+              </dayTypes>
+            </AvailabilityCondition>
+          </validityConditions>
+        </Parking>
+        """;
+
+  private static final String NETEX_FRAGMENT_MIDNIGHT_OPEN =
+    """
+        <Parking xmlns="http://www.netex.org.uk/netex" version="1" id="FSR:Parking:liipi-1">
+          <validityConditions>
+            <AvailabilityCondition version="1" id="FSR:Parking:liipi-1:AvailabilityCondition:1">
+              <IsAvailable>true</IsAvailable>
+              <dayTypes>
+                <DayTypeRef ref="FSR:DayType:BusinessDay"/>
+              </dayTypes>
+              <timebands>
+                <Timeband version="1" id="FSR:Parking:liipi-1:Timeband:1">
+                  <StartTime>00:00:00</StartTime>
+                  <EndTime>00:00:00</EndTime>
+                </Timeband>
+              </timebands>
+            </AvailabilityCondition>
+          </validityConditions>
+        </Parking>
+        """;
+
+  private static final String NETEX_FRAGMENT_MISSING_DAY_TYPE_REF =
+    """
+        <Parking xmlns="http://www.netex.org.uk/netex" version="1" id="FSR:Parking:liipi-1">
+          <validityConditions>
+            <AvailabilityCondition version="1" id="FSR:Parking:liipi-1:AvailabilityCondition:1">
+              <IsAvailable>true</IsAvailable>
+              <timebands>
+                <Timeband version="1" id="FSR:Parking:liipi-1:Timeband:1">
+                  <StartTime>08:00:00</StartTime>
+                  <EndTime>20:00:00</EndTime>
+                </Timeband>
+              </timebands>
+            </AvailabilityCondition>
+          </validityConditions>
+        </Parking>
+        """;
+
+  private static final String NETEX_FRAGMENT_MISSING_END_TIME =
+    """
+        <Parking xmlns="http://www.netex.org.uk/netex" version="1" id="FSR:Parking:liipi-1">
+          <validityConditions>
+            <AvailabilityCondition version="1" id="FSR:Parking:liipi-1:AvailabilityCondition:1">
+              <IsAvailable>true</IsAvailable>
+              <dayTypes>
+                <DayTypeRef ref="FSR:DayType:BusinessDay"/>
+              </dayTypes>
+              <timebands>
+                <Timeband version="1" id="FSR:Parking:liipi-1:Timeband:1">
+                  <StartTime>08:00:00</StartTime>
+                </Timeband>
+              </timebands>
+            </AvailabilityCondition>
+          </validityConditions>
+        </Parking>
+        """;
+
+  private static final String NETEX_FRAGMENT_INVALID_TIME_RANGE =
+    """
+        <Parking xmlns="http://www.netex.org.uk/netex" version="1" id="FSR:Parking:liipi-1">
+          <validityConditions>
+            <AvailabilityCondition version="1" id="FSR:Parking:liipi-1:AvailabilityCondition:1">
+              <IsAvailable>true</IsAvailable>
+              <dayTypes>
+                <DayTypeRef ref="FSR:DayType:BusinessDay"/>
+              </dayTypes>
+              <timebands>
+                <Timeband version="1" id="FSR:Parking:liipi-1:Timeband:1">
+                  <StartTime>20:00:00</StartTime>
+                  <EndTime>08:00:00</EndTime>
+                </Timeband>
+              </timebands>
+            </AvailabilityCondition>
+          </validityConditions>
+        </Parking>
+        """;
+
+  private ValidationTree validationTree;
+
+  @BeforeEach
+  void setUp() {
+    validationTree = new DefaultParkingValidationTreeFactory().builder().build();
+  }
+
+  @Test
+  void testValidParkingWithOpeningHours() {
+    XPathRuleValidationContext context = TestValidationContextBuilder
+      .ofNetexFragment(NETEX_FRAGMENT_VALID)
+      .build();
+    assertTrue(validationTree.validate(context).isEmpty());
+  }
+
+  @Test
+  void testValidParkingWithMidnightOpenHours() {
+    XPathRuleValidationContext context = TestValidationContextBuilder
+      .ofNetexFragment(NETEX_FRAGMENT_MIDNIGHT_OPEN)
+      .build();
+    assertTrue(
+      validationTree.validate(context, CODE_PARKING_TIMEBAND_INVALID_TIME_RANGE).isEmpty()
+    );
+  }
+
+  @Test
+  void testAvailabilityConditionWithoutDayTypeRef() {
+    XPathRuleValidationContext context = TestValidationContextBuilder
+      .ofNetexFragment(NETEX_FRAGMENT_MISSING_DAY_TYPE_REF)
+      .build();
+    List<ValidationIssue> issues = validationTree.validate(
+      context,
+      CODE_PARKING_AVAILABILITY_CONDITION_WITHOUT_DAY_TYPE
+    );
+    assertEquals(1, issues.size());
+    assertEquals(
+      CODE_PARKING_AVAILABILITY_CONDITION_WITHOUT_DAY_TYPE,
+      issues.get(0).rule().code()
+    );
+  }
+
+  @Test
+  void testTimebandWithoutEndTime() {
+    XPathRuleValidationContext context = TestValidationContextBuilder
+      .ofNetexFragment(NETEX_FRAGMENT_MISSING_END_TIME)
+      .build();
+    List<ValidationIssue> issues = validationTree.validate(
+      context,
+      CODE_PARKING_TIMEBAND_WITHOUT_START_OR_END_TIME
+    );
+    assertEquals(1, issues.size());
+    assertEquals(
+      CODE_PARKING_TIMEBAND_WITHOUT_START_OR_END_TIME,
+      issues.get(0).rule().code()
+    );
+  }
+
+  @Test
+  void testTimebandWithEndTimeBeforeStartTime() {
+    XPathRuleValidationContext context = TestValidationContextBuilder
+      .ofNetexFragment(NETEX_FRAGMENT_INVALID_TIME_RANGE)
+      .build();
+    List<ValidationIssue> issues = validationTree.validate(
+      context,
+      CODE_PARKING_TIMEBAND_INVALID_TIME_RANGE
+    );
+    assertEquals(1, issues.size());
+    assertEquals(CODE_PARKING_TIMEBAND_INVALID_TIME_RANGE, issues.get(0).rule().code());
+  }
+}

--- a/src/test/java/org/entur/netex/validation/validator/xpath/tree/DefaultSiteFrameValidationTreeFactoryTest.java
+++ b/src/test/java/org/entur/netex/validation/validator/xpath/tree/DefaultSiteFrameValidationTreeFactoryTest.java
@@ -3,6 +3,7 @@ package org.entur.netex.validation.validator.xpath.tree;
 import static org.entur.netex.validation.validator.xpath.tree.DefaultSiteFrameValidationTreeFactory.CODE_SITE_FRAME_IN_COMMON_FILE;
 import static org.entur.netex.validation.validator.xpath.tree.DefaultSiteFrameValidationTreeFactory.CODE_SITE_FRAME_IN_LINE_FILE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.entur.netex.validation.test.xpath.support.TestValidationContextBuilder;
@@ -14,9 +15,20 @@ import org.junit.jupiter.api.Test;
 
 class DefaultSiteFrameValidationTreeFactoryTest {
 
-  private static final String NETEX_FRAGMENT_INVALID =
+  private static final String NETEX_FRAGMENT_WITHOUT_PARKING =
     """
         <SiteFrame xmlns="http://www.netex.org.uk/netex" version="1" id="AKT:TimetableFrame:484392"/>
+        """;
+
+  private static final String NETEX_FRAGMENT_WITH_PARKING =
+    """
+        <SiteFrame xmlns="http://www.netex.org.uk/netex" version="1" id="FSR:SiteFrame:1">
+          <parkings>
+            <Parking version="1" id="FSR:Parking:liipi-1">
+              <Name>Test Parking</Name>
+            </Parking>
+          </parkings>
+        </SiteFrame>
         """;
 
   private ValidationTree validationTree;
@@ -29,7 +41,7 @@ class DefaultSiteFrameValidationTreeFactoryTest {
   @Test
   void testSiteFrameInLineFile() {
     XPathRuleValidationContext xpathValidationContext = TestValidationContextBuilder
-      .ofNetexFragment(NETEX_FRAGMENT_INVALID)
+      .ofNetexFragment(NETEX_FRAGMENT_WITHOUT_PARKING)
       .build();
     List<ValidationIssue> validationIssues = validationTree.validate(
       xpathValidationContext,
@@ -42,7 +54,7 @@ class DefaultSiteFrameValidationTreeFactoryTest {
   @Test
   void testSiteFrameInCommonFile() {
     XPathRuleValidationContext xpathValidationContext = TestValidationContextBuilder
-      .ofNetexFragment(NETEX_FRAGMENT_INVALID)
+      .ofNetexFragment(NETEX_FRAGMENT_WITHOUT_PARKING)
       .withFilename("_common.xml")
       .build();
     List<ValidationIssue> validationIssues = validationTree.validate(
@@ -51,5 +63,30 @@ class DefaultSiteFrameValidationTreeFactoryTest {
     );
     assertEquals(1, validationIssues.size());
     assertEquals(CODE_SITE_FRAME_IN_COMMON_FILE, validationIssues.get(0).rule().code());
+  }
+
+  @Test
+  void testSiteFrameWithParkingIsNotUnexpectedInLineFile() {
+    XPathRuleValidationContext xpathValidationContext = TestValidationContextBuilder
+      .ofNetexFragment(NETEX_FRAGMENT_WITH_PARKING)
+      .build();
+    List<ValidationIssue> validationIssues = validationTree.validate(
+      xpathValidationContext,
+      CODE_SITE_FRAME_IN_LINE_FILE
+    );
+    assertTrue(validationIssues.isEmpty());
+  }
+
+  @Test
+  void testSiteFrameWithParkingIsNotUnexpectedInCommonFile() {
+    XPathRuleValidationContext xpathValidationContext = TestValidationContextBuilder
+      .ofNetexFragment(NETEX_FRAGMENT_WITH_PARKING)
+      .withFilename("_parking.xml")
+      .build();
+    List<ValidationIssue> validationIssues = validationTree.validate(
+      xpathValidationContext,
+      CODE_SITE_FRAME_IN_COMMON_FILE
+    );
+    assertTrue(validationIssues.isEmpty());
   }
 }


### PR DESCRIPTION
## Summary

Adds XPath validation rules for `AvailabilityCondition` elements on `Parking` entities inside a `SiteFrame`.

### Changes

**`DefaultSiteFrameValidationTreeFactory`**
Narrows the 'unexpected SiteFrame' warning so it only fires when the `SiteFrame` contains no `Parking` elements. A `SiteFrame` used exclusively for park-and-ride data is intentional and should not be warned against.

**`DefaultParkingValidationTreeFactory`** (new)
Three validation rules for `Parking/validityConditions/AvailabilityCondition`:
- `PARKING_AVAILABILITY_CONDITION_WITHOUT_DAY_TYPE` (ERROR): Each `AvailabilityCondition` must reference a `DayType` via `dayTypes/DayTypeRef`.
- `PARKING_TIMEBAND_WITHOUT_START_OR_END_TIME` (ERROR): Each `Timeband` must have both `StartTime` and `EndTime`.
- `PARKING_TIMEBAND_INVALID_TIME_RANGE` (ERROR): `EndTime` must not be before `StartTime` (00:00:00 is treated as midnight/24h and is exempt).

**`PublicationDeliveryValidationTreeFactory`**
Registers the new factory so parking rules run for both direct data-objects and frames-inside-CompositeFrame contexts.

### Notes

This is part of a NeTEx Nordic CCB proposal to formally support park-and-ride opening hours (`AvailabilityCondition` inside `Parking/validityConditions`). All 270 tests pass.